### PR TITLE
Changing ui_page in manifest to loadscreen so Redm loads it first

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -19,6 +19,6 @@ files {
     'config.js'
 }
 
-ui_page 'ui/index.html'
+loadscreen 'ui/index.html'
 
 version '1.1.3'

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -21,4 +21,4 @@ files {
 
 loadscreen 'ui/index.html'
 
-version '1.1.3'
+version '1.2.0'


### PR DESCRIPTION
Redm is looking for loadscreen in the manifest, since its not defined in the manifest the resource is shown really late to clients. 
Support ticket [here](https://discord.com/channels/1021957724440899584/1411658392451153920)
This small change ensures the loading screen is shown first, test and validated on vorp server. 